### PR TITLE
Add requirements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Specify PDDL generator parameters and their value ranges and let BPG generate
 PDDL tasks for you.
 
+## Requirements
+
+    python=3.8
 
 ## Installation
 


### PR DESCRIPTION
Using later versions of Python will result in errors when installing `scikit-learn-1.0`. More specifically this error: `ModuleNotFoundError: No module named 'distutils.msvccompiler'`

